### PR TITLE
change title for search advantage

### DIFF
--- a/docs/home/Index.mdx
+++ b/docs/home/Index.mdx
@@ -6,8 +6,8 @@ hide_table_of_contents: true
 
 import Homepage from '@site/src/components/Homepage.js'
 
-# [MonunDocs](https://monun.me/)
-[Monun(각별)](https://github.com/monun) 플러그인 & 라이브러리 문서
+# [Monun Docs](https://monun.me/)
+[monun(각별)](https://github.com/monun) 플러그인 & 라이브러리 문서
 
 <Homepage></Homepage>
 

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -6,7 +6,7 @@ const copyrightYear = currentYear !== 2021 ? `2021-${currentYear}` : '2021';
 
 /** @type {import('@docusaurus/types').DocusaurusConfig} */
 module.exports = {
-  title: 'Monun Docs',
+  title: '각별 | monun',
   tagline: '',
   url: 'https://monun.me',
   baseUrl: '/',


### PR DESCRIPTION
monun보다 각별이라는 이름이 시청자들에겐 친숙하기 때문에 메인페이지 제목을 각별 | monun으로 바꿔서 검색이 더 되게 해보았습니다